### PR TITLE
Add DSECS toolbox inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
-  push:
     branches: [ staging ]
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install package (On Windows; Skip DSECS)
+    - name: Install package (On Windows; Include DSECS)
       if: runner.os == 'Windows'
-      run: python -m pip install .[test]
+      run: python -m pip install .[test,dsecs]
 
     - name: Test package (On Linux / macOS)
       if: runner.os != 'Windows'
@@ -61,9 +61,9 @@ jobs:
         viresclient set_token "https://vires.services/ows" ${{ secrets.VIRES_TOKEN }}
         viresclient set_default_server https://vires.services/ows
 
-    - name: Test package (On Windows; Skip DSECS)
+    - name: Test package (On Windows; Include DSECS)
       if: runner.os == 'Windows'
-      run: python -m pytest -ra -m "not dsecs"
+      run: python -m pytest -ra
 
     - name: Test package (On Linux / macOS)
       if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,12 @@ jobs:
         viresclient set_default_server https://vires.services/ows
 
     - name: Test package
-      run: python -m pytest -ra
+      run: |
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          python -m pytest -ra -m "not dsecs"
+        else
+          python -m pytest -ra
+        fi
 
 
   # dist:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,7 @@ jobs:
       if: runner.os == 'Windows'
       run: |
         python -m pip install .[test]
-        python -m pip install --no-use-pep517 \
-          --global-option build_ext \
-          --global-option --compiler=mingw32 \
-          --global-option --fcompiler=gfortran \
-          apexpy
+        python -m pip install --no-use-pep517 --global-option build_ext --global-option --compiler=mingw32 --global-option --fcompiler=gfortran apexpy
         python -m pip install .[test,dsecs]
 
     - name: Test package (On Linux / macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,16 @@ jobs:
         # - python-version: pypy-3.8
         #   runs-on: ubuntu-latest
 
-
     steps:
+    - name: Install gfortran (on macOS & Windows)
+      run:   |
+             if [ "$RUNNER_OS" == "macOS" ]; then
+                  brew reinstall gfortran
+             elif [ "$RUNNER_OS" == "Windows" ]; then
+                  choco install mingw
+             fi
+      shell: bash
+
     - uses: actions/checkout@v2
 
     - uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,13 @@ jobs:
         viresclient set_token "https://vires.services/ows" ${{ secrets.VIRES_TOKEN }}
         viresclient set_default_server https://vires.services/ows
 
+    - name: Test package (On Windows; Skip DSECS)
+      if: runner.os == 'Windows'
+      run: python -m pytest -ra -m "not dsecs"
+    
     - name: Test package
-      run: |
-        if [ "$RUNNER_OS" == "Windows" ]; then
-          python -m pytest -ra -m "not dsecs"
-        else
-          python -m pytest -ra
-        fi
+      if: runner.os != 'Windows'
+      run: python -m pytest -ra
 
 
   # dist:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
   checks:
     name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
-    needs: [pre-commit]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,8 @@ jobs:
         #   runs-on: ubuntu-latest
 
     steps:
-    - name: Setup gfortran (Windows)
-      uses: msys2/setup-msys2@v2
-      if: runner.os == 'Windows'
-      with:
-        install: >-
-          base-devel
 
-    - name: Install gfortran (on macOS)
+    - name: Fix install of gfortran (on macOS)
       if: runner.os == 'macOS'
       run: brew reinstall gfortran
       shell: bash
@@ -48,14 +42,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install package (On Windows; Include DSECS)
+    - name: Install package (On Windows; Exclude DSECS (apexpy))
       if: runner.os == 'Windows'
       run: |
         python -m pip install .[test]
-        python -m pip install --no-use-pep517 --global-option build_ext --global-option --compiler=mingw32 --global-option --fcompiler=gfortran apexpy
-        python -m pip install .[test,dsecs]
 
-    - name: Test package (On Linux / macOS)
+    - name: Install package (On Linux / macOS)
       if: runner.os != 'Windows'
       run: python -m pip install .[test,dsecs]
 
@@ -64,9 +56,9 @@ jobs:
         viresclient set_token "https://vires.services/ows" ${{ secrets.VIRES_TOKEN }}
         viresclient set_default_server https://vires.services/ows
 
-    - name: Test package (On Windows; Include DSECS)
+    - name: Test package (On Windows; Exclude DSECS)
       if: runner.os == 'Windows'
-      run: python -m pytest -ra
+      run: python -m pytest -ra -m "not dsecs"
 
     - name: Test package (On Linux / macOS)
       if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,13 @@ jobs:
 
     - name: Install package (On Windows; Include DSECS)
       if: runner.os == 'Windows'
-      run: | 
+      run: |
         python -m pip install .[test]
-        python -m pip install --no-use-pep517 --global-option build_ext --global-option --compiler=mingw32 apexpy
+        python -m pip install --no-use-pep517 \
+          --global-option build_ext \
+          --global-option --compiler=mingw32 \
+          --global-option --fcompiler=gfortran \
+          apexpy
         python -m pip install .[test,dsecs]
 
     - name: Test package (On Linux / macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install package
+    - name: Install package (On Windows; Skip DSECS)
+      if: runner.os == 'Windows'
+      run: python -m pip install .[test]
+
+    - name: Test package (On Linux / macOS)
+      if: runner.os != 'Windows'
       run: python -m pip install .[test,dsecs]
 
     - name: Configure token access
@@ -56,8 +61,8 @@ jobs:
     - name: Test package (On Windows; Skip DSECS)
       if: runner.os == 'Windows'
       run: python -m pytest -ra -m "not dsecs"
-    
-    - name: Test package
+
+    - name: Test package (On Linux / macOS)
       if: runner.os != 'Windows'
       run: python -m pytest -ra
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install package
-      run: python -m pip install .[test]
+      run: python -m pip install .[test,dsecs]
 
     - name: Configure token access
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,16 @@ jobs:
         #   runs-on: ubuntu-latest
 
     steps:
-    - name: Install gfortran (on macOS & Windows)
-      run:   |
-             if [ "$RUNNER_OS" == "macOS" ]; then
-                  brew reinstall gfortran
-             elif [ "$RUNNER_OS" == "Windows" ]; then
-                  choco install mingw
-             fi
+    - name: Setup gfortran (Windows)
+      uses: msys2/setup-msys2@v2
+      if: runner.os == 'Windows'
+      with:
+        install: >-
+          base-devel
+
+    - name: Install gfortran (on macOS)
+      if: runner.os == 'macOS'
+      run: brew reinstall gfortran
       shell: bash
 
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,10 @@ jobs:
 
     - name: Install package (On Windows; Include DSECS)
       if: runner.os == 'Windows'
-      run: python -m pip install .[test,dsecs]
+      run: | 
+        python -m pip install .[test]
+        python -m pip install --no-use-pep517 --global-option build_ext --global-option --compiler=mingw32 apexpy
+        python -m pip install .[test,dsecs]
 
     - name: Test package (On Linux / macOS)
       if: runner.os != 'Windows'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
   rev: "0.5.0"
   hooks:
     - id: nbstripout
+      args: ["--extra-keys", "metadata.kernelspec metadata.language_info.version"]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.1.0

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,11 +12,8 @@ sphinx:
 # Include PDF and ePub
 formats: all
 
-# Include gfortran, required for apexpy
 build:
   os: ubuntu-20.04
-  apt_packages:
-    - gfortran
   tools:
     python: "3.8"
 
@@ -26,4 +23,4 @@ python:
     path: .
     extra_requirements:
     - docs
-    - dsecs
+    - dsecs_cp38_manylinux

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,3 +19,4 @@ python:
     path: .
     extra_requirements:
     - docs
+    - dsecs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,8 +12,15 @@ sphinx:
 # Include PDF and ePub
 formats: all
 
+# Include gfortran, required for apexpy
+build:
+  os: ubuntu-20.04
+  apt_packages:
+    - gfortran
+  tools:
+    python: "3.8"
+
 python:
-  version: 3.8
   install:
   - method: pip
     path: .

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,14 +1,17 @@
-swarmx
-======
+swarmx modules
+==============
 
-swarmx.toolboxes
-^^^^^^^^^^^^^^^^
+swarmx.toolboxes.fac
+^^^^^^^^^^^^^^^^^^^^
 
-.. autofunction:: swarmx.toolboxes.fac.fac_single_sat
+.. automodule:: swarmx.toolboxes.fac
+    :members:
 
-.. autofunction:: swarmx.toolboxes.fac.fac_single_sat_algo
+swarmx.toolboxes.secs
+^^^^^^^^^^^^^^^^^^^^^
 
-.. autoclass:: swarmx.toolboxes.fac.FacInputs
+.. automodule:: swarmx.toolboxes.secs
+    :members:
 
 swarmx.io
 ^^^^^^^^^

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_copybutton",
     "sphinx.ext.viewcode",
+    "sphinxcontrib.mermaid",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,3 +75,6 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path: list[str] = []
+
+# Fix https://github.com/executablebooks/sphinx-book-theme/issues/105
+html_sourcelink_suffix = ""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,6 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_copybutton",
     "sphinx.ext.viewcode",
-    "sphinxcontrib.mermaid",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ This project is in the early planning stage.
    :caption: Toolbox guides
 
    toolboxes/fac/using_fac
+   toolboxes/secs/using_secs
 
 .. toctree::
   :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,13 @@ This project is in the early planning stage.
 
 .. toctree::
    :maxdepth: 2
+   :caption: Getting started
+
+   introduction
+   installation
+
+.. toctree::
+   :maxdepth: 2
    :caption: Toolbox guides
 
    toolboxes/fac/using_fac

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,19 @@
+# Installation
+
+The package is in early development so is not recommended for use yet. The following instructions are a guide how to set up for testing and evaluation. For development, see the [Development Guide on HackMD](https://hackmd.io/@swarm/dev/%2Ff6YIHfqxT9yL0giWJzhr_Q).
+
+(If you want to begin with a reasonable conda environment file, you can check [this one used for development](https://raw.githubusercontent.com/Swarm-DISC/SwarmX/staging/environment.yml))
+
+Assuming you have a compatible system with git, a fortran compiler, and a Python>=3.8 installation with a recent version of pip, you can install the latest development version from the `staging` branch with:
+
+```
+pip install git+https://github.com/Swarm-DISC/SwarmX@staging#egg=swarmx[dsecs]
+```
+
+The fortran compiler is required in order to install the dependency, apexpy. It may be better to try installing apexpy first and debugging that if you run into trouble.
+
+To bypass installation of apexpy (so disabling usage of the DSECS toolbox), you can use pip without the `[dsecs]` option:
+
+```
+pip install git+https://github.com/Swarm-DISC/SwarmX@staging#egg=swarmx
+```

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,47 @@
+# Introduction
+
+SwarmX is a Python package containing analysis and visualisation tools to interact with Swarm products. We rely on the VirES service (via [viresclient](https://viresclient.readthedocs.io/)) to provide access to data and models as well as frameworks from the Python ecosystem (e.g. Xarray) and specific utilities from the scientific community (e.g. apexpy).
+
+```{mermaid}
+graph LR
+
+    subgraph SwarmX: Analysis Tools
+        direction LR
+        v2[viresclient]
+        algvis(Algorithms<br>Visualisations)
+        v2 -->|Pre-configured<br>inputs| algvis
+        pack[swarmx package]
+        algvis === pack
+        eco[[Python<br>ecosystem]] --> algvis
+    end
+
+    scidev((Expert<br>scientists)) -.->|Project work| algvis
+    eng((Software<br>engineers)) -.->|Maintain<br>Improve| pack
+
+    subgraph Data Access
+        direction LR
+        VS[(VirES Server:<br>One product = one time series<br>Subsampling & subsetting<br>Geomagnetic model evaluation<br>+ more, e.g. conjunctions)]
+        VS -->|VirES<br>API| v[viresclient]
+        v -->|Python<br>datatypes| du([Direct usage<br>Notebooks<br>Other packages])
+    end
+```
+
+The package is structured so that researchers can run high level analysis routines with just a few lines of code which seemlessly pulls in Swarm data underneath, while the steps of the routines are also exposed so that they can be run more flexibly (e.g. with other data).
+
+```{mermaid}
+graph LR
+subgraph SwarmX package
+    direction TB
+    npf[Algorithms<br>NumPy/SciPy etc]
+    viz[Visualisation<br>Matplotlib etc]
+    sds[SwarmX<br>data structures]
+    sds --> npf --> sds --> viz
+    sds --- intf[Convenient interface]
+end
+
+subgraph VirES connection
+    viresclient -->|Swarm<br>products| sds
+end
+npf & viz -.-> usem[Use manually<br>with other data etc]
+intf -.-> used[Use directly]
+```

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -26,7 +26,7 @@ graph LR
     end
 ```
 
-The package is structured so that researchers can run high level analysis routines with just a few lines of code which seemlessly pulls in Swarm data underneath, while the steps of the routines are also exposed so that they can be run more flexibly (e.g. with other data).
+The package is structured so that researchers can run high level analysis routines with just a few lines of code which seamlessly pulls in Swarm data underneath, while the steps of the routines are also exposed so that they can be run more flexibly (e.g. with other data).
 
 ```{mermaid}
 graph LR

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -2,46 +2,8 @@
 
 SwarmX is a Python package containing analysis and visualisation tools to interact with Swarm products. We rely on the VirES service (via [viresclient](https://viresclient.readthedocs.io/)) to provide access to data and models as well as frameworks from the Python ecosystem (e.g. Xarray) and specific utilities from the scientific community (e.g. apexpy).
 
-```{mermaid}
-graph LR
-
-    subgraph SwarmX: Analysis Tools
-        direction LR
-        v2[viresclient]
-        algvis(Algorithms<br>Visualisations)
-        v2 -->|Pre-configured<br>inputs| algvis
-        pack[swarmx package]
-        algvis === pack
-        eco[[Python<br>ecosystem]] --> algvis
-    end
-
-    scidev((Expert<br>scientists)) -.->|Project work| algvis
-    eng((Software<br>engineers)) -.->|Maintain<br>Improve| pack
-
-    subgraph Data Access
-        direction LR
-        VS[(VirES Server:<br>One product = one time series<br>Subsampling & subsetting<br>Geomagnetic model evaluation<br>+ more, e.g. conjunctions)]
-        VS -->|VirES<br>API| v[viresclient]
-        v -->|Python<br>datatypes| du([Direct usage<br>Notebooks<br>Other packages])
-    end
-```
+![](https://mermaid.ink/img/pako:eNqFU9-L2zAM_leMH0bK2j7sMawHhZZxsO3KMsogyYNrq6mvsR0sO3flev_75PTX7caYIWDpkz5J_pQXLp0CnvPGi27Hvv6obGUZHYybk6t4Et78ytncivaAGtlP51o8BaWjtAcZtLND8sXbfyp7AlC2Gmyob4Bom15jNm8b53XYGfy88XdrjVG0GkXiwdFbGjaZ3B1XHibS2a1uogeVMrTtYsDjme6W0Am5LzG1_DzcRQN_FWez2WwAbwBIV5arQ9g5m9jJxAMGMHWd6v9RBay6vpHUCvosWz534ENKJA-NqzHgaMQm06F190jvw56c3x_fETVZVrhtoG5hqGobbQH8Nfeb0DbQl8B703nXw_Hc-DuRFiIINpcS8L_KrIsyW2u_LFgBvgefJ_YHC4z4VaROZ8yRFbQBhuA1DAoVcYPCdK22DfuQ6iKEQEbCvoAzorEQtGSGtqll0Is2DmIm_CN5PYwZTJspIxkfo5Unoeu3bQ1KD52lpPnq_sj6fyxRf9qKq16Kxg-HDmghVMzKxTA4i0jqJ_i7C7Bxbj9M8hB24C-7gfXoqiofcwPeCK3od3hJ7opTrIGK53RVsBWxDRWv7CuFxo6KwlLp4DzPt6JFGHMRgysOVvI8-AiXoIUWpJI5R73-BqYNJ6M)
 
 The package is structured so that researchers can run high level analysis routines with just a few lines of code which seamlessly pulls in Swarm data underneath, while the steps of the routines are also exposed so that they can be run more flexibly (e.g. with other data).
 
-```{mermaid}
-graph LR
-subgraph SwarmX package
-    direction TB
-    npf[Algorithms<br>NumPy/SciPy etc]
-    viz[Visualisation<br>Matplotlib etc]
-    sds[SwarmX<br>data structures]
-    sds --> npf --> sds --> viz
-    sds --- intf[Convenient interface]
-end
-
-subgraph VirES connection
-    viresclient -->|Swarm<br>products| sds
-end
-npf & viz -.-> usem[Use manually<br>with other data etc]
-intf -.-> used[Use directly]
-```
+![](https://mermaid.ink/img/pako:eNpNUclOwzAQ_RXLB04N3CNUiaU3QBWBCinpYWpPWgsvkZdWoe2_M05aSC7OWG8dH7lwEnnJtx66HXt5b2xIm3GoDuDNF-tAfMMWG8vok8qjiMpZ9vE43tiurR_01nkVdybcb_z8LZllf1cJtewZRrEecXv1U69USKBVgKyQoa8QO-2iVpsJMshQj94ZIiECC9EnEZPH8I9hRTHP7sN5ncllCiiYsrGtn5zdo1VoY57RtyCQhNDKxk4Kr5RfVEw4a8eO1-BkK_TAJovTEC0n67yTlCqcstlFLee5ySlYcUtxUkBTfwZkBiw1133mHWhTzMUdejaUG5vnoH8kOZDGZet-zWfcoDegJL3UMcdqOPENNrykX4ktJB0b3tgzQVNHsriQKjrPyxZ0wBmHFF3VW8FLWiVeQc8KqLq5oM6_2Si4CA)

--- a/docs/toolboxes/fac/using_fac.ipynb
+++ b/docs/toolboxes/fac/using_fac.ipynb
@@ -181,11 +181,6 @@
   "interpreter": {
    "hash": "87d67a24c2c5892c025cb327df6d3922c0a9d4e9219e4fcf3b6836bad3fb9136"
   },
-  "kernelspec": {
-   "display_name": "Python 3.8.12 64-bit ('swarmx': conda)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -195,8 +190,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/toolboxes/secs/using_secs.ipynb
+++ b/docs/toolboxes/secs/using_secs.ipynb
@@ -1,0 +1,105 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using the SECS toolbox"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import datetime as dt\n",
+    "from swarmx.toolboxes.secs import SecsInputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`SecsInputs` fetches data from Swarm Alpha and Charlie. The default model used is `\"'CHAOS-Core' + 'CHAOS-Static'\"` (i.e. the internal field model from CHAOS), which can be replaced with, for example, `model=\"IGRF\"` as below (which is faster but less accurate)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inputs = SecsInputs(\n",
+    "    start_time=dt.datetime(2019, 1, 1, hour=0),\n",
+    "    end_time=dt.datetime(2019, 1, 2, hour=2),\n",
+    "    model=\"IGRF\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The data are now available within xarray objects underneath `inputs.s1` (for Swarm Alpha) and `inputs.s2` (for Swarm Charlie)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inputs.s1.xarray"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inputs.s2.xarray"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The numpy arrays can be extracted using the xarray interface:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inputs.s1.xarray[\"Timestamp\"].data"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "f067c6c47a2cb62bc6a3bfa24319dda2792b1a63487d0a36b8f09a14a2a18616"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.8.12 64-bit ('swarmx': conda)",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/toolboxes/secs/using_secs.ipynb
+++ b/docs/toolboxes/secs/using_secs.ipynb
@@ -21,7 +21,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`SecsInputs` fetches data from Swarm Alpha and Charlie. The default model used is `\"'CHAOS-Core' + 'CHAOS-Static'\"` (i.e. the internal field model from CHAOS), which can be replaced with, for example, `model=\"IGRF\"` as below (which is faster but less accurate)."
+    "## Fetching inputs to the toolbox"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`SecsInputs` fetches data from Swarm Alpha and Charlie. The default model used is `\"'CHAOS-Core' + 'CHAOS-Static'\"` (i.e. the internal field model from CHAOS), which can be replaced with, for example, `model=\"IGRF\"` as below (which is faster but less accurate. In real-world usage replace it with, for example:\n",
+    "- `model=\"'CHAOS-Core' + 'CHAOS-Static'\"`\n",
+    "- `model=\"'CHAOS-Core' + 'CHAOS-Static' + 'CHAOS-MMA-Primary' + 'CHAOS-MMA-Secondary'\"`  \n",
+    "   or equivalently `model=\"CHAOS\"` (an alias for the above)Data is fetched separately for each spacecraft and stored together in the returned object."
    ]
   },
   {
@@ -41,6 +51,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Data are fetched separately for each spacecraft and stored together in the returned object. In addition, magnetic apex coordinates are calculated locally and included with the data. Note that the model used is renamed to just `Model` in the dataset (i.e. in the variable `B_NEC_Model`), but the details of the model are available within the `MagneticModels` attribute.\n",
+    "\n",
     "The data are now available within xarray objects underneath `inputs.s1` (for Swarm Alpha) and `inputs.s2` (for Swarm Charlie)."
    ]
   },
@@ -76,6 +88,31 @@
    "outputs": [],
    "source": [
     "inputs.s1.xarray[\"Timestamp\"].data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or using methods built within SwarmX:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inputs.s1.get_array(\"Timestamp\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inputs.s1.get_array(\"B_NEC\")"
    ]
   }
  ],

--- a/docs/toolboxes/secs/using_secs.ipynb
+++ b/docs/toolboxes/secs/using_secs.ipynb
@@ -84,8 +84,9 @@
    "hash": "f067c6c47a2cb62bc6a3bfa24319dda2792b1a63487d0a36b8f09a14a2a18616"
   },
   "kernelspec": {
-   "display_name": "Python 3.8.12 64-bit ('swarmx': conda)",
-   "name": "python3"
+   "display_name": "Python [conda env:swarmx_test]",
+   "language": "python",
+   "name": "conda-env-swarmx_test-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -97,9 +98,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/toolboxes/secs/using_secs.ipynb
+++ b/docs/toolboxes/secs/using_secs.ipynb
@@ -83,11 +83,6 @@
   "interpreter": {
    "hash": "f067c6c47a2cb62bc6a3bfa24319dda2792b1a63487d0a36b8f09a14a2a18616"
   },
-  "kernelspec": {
-   "display_name": "Python [conda env:swarmx_test]",
-   "language": "python",
-   "name": "conda-env-swarmx_test-py"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -97,8 +92,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/environment.yml
+++ b/environment.yml
@@ -8,8 +8,10 @@ dependencies:
   - pipx
   # IDE
   - jupyterlab=3.2
-  - code-server=4.1
-  - jupyter-vscode-proxy=0.1
+  # - code-server=4.1
+  # - jupyter-vscode-proxy=0.1
+  # Compiler required for apexpy
+  - fortran-compiler
   # Dev tools (could be handled by nox)
   - pre-commit
   - pytest
@@ -33,6 +35,7 @@ dependencies:
   - scipy=1.8.0
   - xarray=0.21.1
   - pip:
+    - apexpy==1.1.0
     - viresclient==0.10.1
     - hapiclient==0.2.3
     # This package

--- a/environment.yml
+++ b/environment.yml
@@ -24,6 +24,7 @@ dependencies:
   - myst-parser
   - sphinx-book-theme
   - sphinx-copybutton
+  - sphinx-autobuild
   # Necessary for tqdm progress bars to work in vscode
   - ipywidgets
   # Likely swarmx minimum dependencies
@@ -39,4 +40,4 @@ dependencies:
     - viresclient==0.10.1
     - hapiclient==0.2.3
     # This package
-    - -e .[dev]
+    - -e .[dev,docs,dsecs]

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,7 +34,7 @@ def docs(session: nox.Session) -> None:
     Build the docs. Pass "serve" to serve.
     """
 
-    session.install(".[docs]")
+    session.install(".[docs,dsecs]")
     session.chdir("docs")
     session.run("sphinx-build", "-M", "html", ".", "_build")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,10 @@ filterwarnings = ["error"]
 testpaths = [
     "tests",
 ]
+markers = [
+    "remote",
+    "dsecs",
+]
 
 
 [tool.pycln]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
 [project.optional-dependencies]
 dsecs = [
     "apexpy>=1.1.0",
+    "pyproj>=3",
 ]
 test = [
     "pytest >=6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,11 @@ docs = [
     "matplotlib==3.5.1",
     "ipywidgets==7.7.0",
 ]
+dsecs_cp38_manylinux = [
+    # pre-built binary for apexpy, for Python3.8 on Linux
+    "https://github.com/smithara/apexpy/releases/download/v1.1.0-binaries/apexpy-1.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+    "pyproj>=3",
+]
 
 [project.urls]
 homepage = "https://github.com/Swarm-DISC/SwarmX"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,12 @@ dev = [
 ]
 docs = [
     "Sphinx==4.4",
-    "myst-parser>=0.15.2",
-    "myst-nb>=0.13.1",
-    "sphinx-book-theme>=0.1.0",
-    "sphinx_copybutton",
-    "matplotlib>=3.5.1"
+    "myst-parser==0.15.2",
+    "myst-nb==0.13.1",
+    "sphinx-book-theme==0.3.2",
+    "sphinx_copybutton==0.5.0",
+    "matplotlib==3.5.1",
+    "ipywidgets==7.7.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ docs = [
     "myst-nb==0.13.1",
     "sphinx-book-theme==0.3.2",
     "sphinx_copybutton==0.5.0",
+    "sphinxcontrib-mermaid==0.7.1",
     "matplotlib==3.5.1",
     "ipywidgets==7.7.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ docs = [
     "myst-nb==0.13.1",
     "sphinx-book-theme==0.3.2",
     "sphinx_copybutton==0.5.0",
-    "sphinxcontrib-mermaid==0.7.1",
     "matplotlib==3.5.1",
     "ipywidgets==7.7.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,10 @@ dsecs = [
     "apexpy>=1.1.0",
     "pyproj>=3",
 ]
+dsecs_cp38_manylinux = [
+    "apexpy @ https://github.com/smithara/apexpy/releases/download/v1.1.0-binaries/apexpy-1.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+    "pyproj>=3"
+]
 test = [
     "pytest >=6",
 ]
@@ -63,11 +67,7 @@ docs = [
     "matplotlib==3.5.1",
     "ipywidgets==7.7.0",
 ]
-dsecs_cp38_manylinux = [
-    # pre-built binary for apexpy, for Python3.8 on Linux
-    "https://github.com/smithara/apexpy/releases/download/v1.1.0-binaries/apexpy-1.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-    "pyproj>=3",
-]
+
 
 [project.urls]
 homepage = "https://github.com/Swarm-DISC/SwarmX"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dsecs = [
+    "apexpy>=1.1.0",
+]
 test = [
     "pytest >=6",
 ]

--- a/src/swarmx/io/_data_container.py
+++ b/src/swarmx/io/_data_container.py
@@ -223,7 +223,9 @@ class ExternalData:
             )
         return ds.get(variable).data  # type: ignore
 
-    def append_array(self, varname, data, dims=("Timestamp",)):
+    def append_array(
+        self, varname, data, dims=("Timestamp",), units=None, description=None
+    ):
         """Append a new variable to the dataset
 
         Parameters
@@ -234,12 +236,20 @@ class ExternalData:
             Array of data, of same dimensions as dims
         dims: tuple, default=("Timestamp",)
             Dimension names
+        units: str
+            Units to attach to the data
+        description: str
+            Description to attach to the data
         """
         self.xarray = self.xarray.assign(
             {
                 varname: ("Timestamp", data),
             }
         )
+        if units:
+            self.xarray[varname].attrs["units"] = units
+        if description:
+            self.xarray[varname].attrs["description"] = description
         return self
 
 

--- a/src/swarmx/io/_data_container.py
+++ b/src/swarmx/io/_data_container.py
@@ -235,9 +235,11 @@ class ExternalData:
         dims: tuple, default=("Timestamp",)
             Dimension names
         """
-        self.xarray = self.xarray.assign({
-            varname: ("Timestamp", data),
-        })
+        self.xarray = self.xarray.assign(
+            {
+                varname: ("Timestamp", data),
+            }
+        )
         return self
 
 

--- a/src/swarmx/io/_data_container.py
+++ b/src/swarmx/io/_data_container.py
@@ -223,6 +223,23 @@ class ExternalData:
             )
         return ds.get(variable).data  # type: ignore
 
+    def append_array(self, varname, data, dims=("Timestamp",)):
+        """Append a new variable to the dataset
+
+        Parameters
+        ----------
+        varname: str
+            Name to give to the data variable
+        data: ndarray
+            Array of data, of same dimensions as dims
+        dims: tuple, default=("Timestamp",)
+            Dimension names
+        """
+        self.xarray = self.xarray.assign({
+            varname: ("Timestamp", data),
+        })
+        return self
+
 
 class MagExternalData(ExternalData):
     """Demo class for accessing magnetic data

--- a/src/swarmx/toolboxes/secs/__init__.py
+++ b/src/swarmx/toolboxes/secs/__init__.py
@@ -1,3 +1,6 @@
-from swarmx.toolboxes.secs.secs_inputs import SecsInputSingleSat, SecsInputs
+from swarmx.toolboxes.secs.secs_inputs import SecsInputs, SecsInputSingleSat
 
-__all__ = ("SecsInputSingleSat", "SecsInputs",)
+__all__ = (
+    "SecsInputSingleSat",
+    "SecsInputs",
+)

--- a/src/swarmx/toolboxes/secs/__init__.py
+++ b/src/swarmx/toolboxes/secs/__init__.py
@@ -1,0 +1,3 @@
+from swarmx.toolboxes.secs.secs_inputs import SecsInputs
+
+__all__ = ("SecsInputs",)

--- a/src/swarmx/toolboxes/secs/__init__.py
+++ b/src/swarmx/toolboxes/secs/__init__.py
@@ -1,3 +1,3 @@
-from swarmx.toolboxes.secs.secs_inputs import SecsInputs
+from swarmx.toolboxes.secs.secs_inputs import SecsInputSingleSat, SecsInputs
 
-__all__ = ("SecsInputs",)
+__all__ = ("SecsInputSingleSat", "SecsInputs",)

--- a/src/swarmx/toolboxes/secs/secs_inputs.py
+++ b/src/swarmx/toolboxes/secs/secs_inputs.py
@@ -66,8 +66,20 @@ class SecsInputs:
         # Append Apex coordinates to each dataset
         for s in (self.s1, self.s2):
             mlat, mlon = self._calc_apex_coords_from_inputs(s)
-            s.append_array("ApexLatitude", mlat, dims=("Timestamp",))
-            s.append_array("ApexLongitude", mlon, dims=("Timestamp",))
+            s.append_array(
+                "ApexLatitude",
+                mlat,
+                dims=("Timestamp",),
+                units="deg",
+                description="Magnetic apex latitude",
+            )
+            s.append_array(
+                "ApexLongitude",
+                mlon,
+                dims=("Timestamp",),
+                units="deg",
+                description="Magnetic apex longitude",
+            )
 
     @staticmethod
     def _spherical_geocentric_to_geodetic(lat, lon, rad):

--- a/src/swarmx/toolboxes/secs/secs_inputs.py
+++ b/src/swarmx/toolboxes/secs/secs_inputs.py
@@ -1,3 +1,7 @@
+from apexpy import Apex
+from numpy import deg2rad, sin, cos
+from pyproj import CRS, Transformer
+
 from swarmx.io import ExternalData
 
 
@@ -41,6 +45,7 @@ class SecsInputs:
     ):
         if spacecraft_pair != "Alpha-Charlie":
             raise NotImplementedError("Only the Alpha-Charlie pair are configured")
+        # Fetch external data
         inputs_1 = SecsInputSingleSat(
             collection="SW_OPER_MAGA_LR_1B",
             model=model,
@@ -55,5 +60,104 @@ class SecsInputs:
             end_time=end_time,
             viresclient_kwargs=viresclient_kwargs,
         )
+        # Store datasets as properties
         self.s1 = inputs_1
         self.s2 = inputs_2
+        # Append Apex coordinates to each dataset
+        for s in (self.s1, self.s2):
+            mlat, mlon = self._calc_apex_coords_from_inputs(s)
+            s.append_array("ApexLatitude", mlat, dims=("Timestamp",))
+            s.append_array("ApexLongitude", mlon, dims=("Timestamp",))
+
+    @staticmethod
+    def _spherical_geocentric_to_geodetic(lat, lon, rad):
+        """Convert from geocentric coordinates to geodetic lat/lon and height
+
+        Parameters
+        ----------
+        lat : array_like
+            Geocentric latitude (degrees)
+        lon : array_like
+            Geocentric longitude (degrees)
+        rad : array_like
+            Geocentric radius (metres)
+
+        Returns
+        -------
+        lat: ndarray
+            Geodetic latitude (degrees)
+        lon: ndarray
+            Geodetic longitude (degrees)
+        alt: ndarray
+            Geodetic altitude (metres)
+        """
+        # Convert to Cartesian x,y,z
+        s_p = sin(deg2rad(lon))
+        c_p = cos(deg2rad(lon))
+        s_t = sin(deg2rad(90-lat))
+        c_t = cos(deg2rad(90-lat))
+        x = rad*c_p*s_t
+        y = rad*s_p*s_t
+        z = rad*c_t
+        # Use PROJ to make the transformation
+        ecef = CRS.from_proj4("+proj=geocent +ellps=WGS84 +datum=WGS84")
+        lla = CRS.from_proj4("+proj=longlat +ellps=WGS84 +datum=WGS84")
+        transformer = Transformer.from_crs(ecef, lla)
+        lon, lat, alt = transformer.transform(x, y, z, radians=False)
+        return lat, lon, alt
+
+    @staticmethod
+    def _calc_apex_coords(date, lat, lon, rad):
+        """Calculate Apex coordinates
+
+        Parameters
+        ----------
+        date: datetime
+            Epoch date to use for Apex calculations
+        lat : array_like
+            Geocentric latitude (degrees)
+        lon : array_like
+            Geocentric longitude (degrees)
+        rad : array_like
+            Geocentric radius (metres)
+
+        Returns
+        -------
+        mlat: ndarray
+            Mangnetic apex latitude (degrees)
+        mlon: ndarray
+            Magnetic apex longitude (degrees)
+        """
+        A = Apex(date)
+        geod_lat, lon, height = SecsInputs._spherical_geocentric_to_geodetic(
+            lat, lon, rad
+        )
+        mlat, mlon = A.convert(geod_lat, lon, 'geo', 'apex', height=height/1e3)
+        return mlat, mlon
+
+    @staticmethod
+    def _calc_apex_coords_from_inputs(s):
+        """Calculate Apex coordinates from SecsInputSingleSat
+
+        Parameters
+        ----------
+        s: SecsInputSingleSat
+            Object that contains a xarray.Dataset from a single satellite
+
+        Returns
+        -------
+        mlat: ndarray
+            Mangnetic apex latitude (degrees)
+        mlon: ndarray
+            Magnetic apex longitude (degrees)
+        """
+        # Get current date as datetime
+        date = s.get_array("Timestamp")[0].astype('M8[ms]').astype('O')
+        # Evaluate apex coordinates
+        mlat, mlon = SecsInputs._calc_apex_coords(
+            date,
+            s.get_array("Latitude"),
+            s.get_array("Longitude"),
+            s.get_array("Radius"),
+        )
+        return mlat, mlon

--- a/src/swarmx/toolboxes/secs/secs_inputs.py
+++ b/src/swarmx/toolboxes/secs/secs_inputs.py
@@ -1,5 +1,5 @@
 from apexpy import Apex
-from numpy import deg2rad, sin, cos
+from numpy import cos, deg2rad, sin
 from pyproj import CRS, Transformer
 
 from swarmx.io import ExternalData
@@ -94,11 +94,11 @@ class SecsInputs:
         # Convert to Cartesian x,y,z
         s_p = sin(deg2rad(lon))
         c_p = cos(deg2rad(lon))
-        s_t = sin(deg2rad(90-lat))
-        c_t = cos(deg2rad(90-lat))
-        x = rad*c_p*s_t
-        y = rad*s_p*s_t
-        z = rad*c_t
+        s_t = sin(deg2rad(90 - lat))
+        c_t = cos(deg2rad(90 - lat))
+        x = rad * c_p * s_t
+        y = rad * s_p * s_t
+        z = rad * c_t
         # Use PROJ to make the transformation
         ecef = CRS.from_proj4("+proj=geocent +ellps=WGS84 +datum=WGS84")
         lla = CRS.from_proj4("+proj=longlat +ellps=WGS84 +datum=WGS84")
@@ -132,7 +132,7 @@ class SecsInputs:
         geod_lat, lon, height = SecsInputs._spherical_geocentric_to_geodetic(
             lat, lon, rad
         )
-        mlat, mlon = A.convert(geod_lat, lon, 'geo', 'apex', height=height/1e3)
+        mlat, mlon = A.convert(geod_lat, lon, "geo", "apex", height=height / 1e3)
         return mlat, mlon
 
     @staticmethod
@@ -152,7 +152,7 @@ class SecsInputs:
             Magnetic apex longitude (degrees)
         """
         # Get current date as datetime
-        date = s.get_array("Timestamp")[0].astype('M8[ms]').astype('O')
+        date = s.get_array("Timestamp")[0].astype("M8[ms]").astype("O")
         # Evaluate apex coordinates
         mlat, mlon = SecsInputs._calc_apex_coords(
             date,

--- a/src/swarmx/toolboxes/secs/secs_inputs.py
+++ b/src/swarmx/toolboxes/secs/secs_inputs.py
@@ -1,0 +1,59 @@
+from swarmx.io import ExternalData
+
+
+class SecsInputSingleSat(ExternalData):
+    """Accessing external data: magnetic data from one satellite"""
+
+    COLLECTIONS = [
+        *[f"SW_OPER_MAG{x}_LR_1B" for x in "ABC"],
+    ]
+
+    DEFAULTS = {
+        "measurements": ["B_NEC", "Flags_B"],
+        "model": "'CHAOS-Core' + 'CHAOS-Static'",
+        "auxiliaries": ["QDLat", "QDLon", "MLT"],
+        "sampling_step": None,
+    }
+
+
+class SecsInputs:
+    """Accessing external data: inputs to SECS algorithm
+
+    Examples
+    --------
+    >>> d = SecsInputs(
+    >>>     start_time="2022-01-01", end_time="2022-01-02",
+    >>>     model="'CHAOS-Core' + 'CHAOS-Static'",
+    >>>     viresclient_kwargs=dict(asynchronous=True, show_progress=True)
+    >>> )
+    >>> d.s1.xarray  # Returns xarray of data from satellite 1 (Alpha)
+    >>> d.s2.xarray  # Returns xarray of data from satellite 2 (Charlie)
+    >>> d.s1.get_array("B_NEC")  # Returns numpy array
+    """
+
+    def __init__(
+        self,
+        spacecraft_pair="Alpha-Charlie",
+        start_time=None,
+        end_time=None,
+        model="'CHAOS-Core' + 'CHAOS-Static'",
+        viresclient_kwargs=None,
+    ):
+        if spacecraft_pair != "Alpha-Charlie":
+            raise NotImplementedError("Only the Alpha-Charlie pair are configured")
+        inputs_1 = SecsInputSingleSat(
+            collection="SW_OPER_MAGA_LR_1B",
+            model=model,
+            start_time=start_time,
+            end_time=end_time,
+            viresclient_kwargs=viresclient_kwargs,
+        )
+        inputs_2 = SecsInputSingleSat(
+            collection="SW_OPER_MAGC_LR_1B",
+            model=model,
+            start_time=start_time,
+            end_time=end_time,
+            viresclient_kwargs=viresclient_kwargs,
+        )
+        self.s1 = inputs_1
+        self.s2 = inputs_2

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import pytest
 from xarray import Dataset
 
 from swarmx.io import ExternalData, MagExternalData, ViresDataFetcher
 
 
+@pytest.mark.remote
 def test_ViresDataFetcher():
     parameters = {
         "collection": "SW_OPER_MAGA_LR_1B",
@@ -33,6 +35,7 @@ def test_ViresDataFetcher():
         raise ValueError(f"Erroneous data_vars: {ds.data_vars}")
 
 
+@pytest.mark.remote
 def test_ExternalData():
     start = "2022-01-01T00:00:00"
     end = "2022-01-01T00:01:00"
@@ -59,6 +62,7 @@ def test_ExternalData():
     assert not vars_to_check_nonpresence.issubset(returned_vars)
 
 
+@pytest.mark.remote
 def test_MagExternalData():
     start = "2022-01-01T00:00:00"
     end = "2022-01-01T00:01:00"

--- a/tests/test_toolbox_fac.py
+++ b/tests/test_toolbox_fac.py
@@ -1,8 +1,11 @@
 import datetime as dt
 
+import pytest
+
 from swarmx.toolboxes.fac import FacInputs, fac_single_sat
 
 
+@pytest.mark.remote
 def test_fac_single_sat():
     start = dt.datetime.fromisoformat("2022-01-01T00:00:00")
     end = dt.datetime.fromisoformat("2022-01-01T00:01:00")

--- a/tests/toolboxes/secs/test_secs_inputs.py
+++ b/tests/toolboxes/secs/test_secs_inputs.py
@@ -1,6 +1,6 @@
 import datetime as dt
 
-from swarmx.toolboxes.secs import SecsInputSingleSat, SecsInputs
+from swarmx.toolboxes.secs import SecsInputs, SecsInputSingleSat
 
 
 def test_SecsInputSingleSat():

--- a/tests/toolboxes/secs/test_secs_inputs.py
+++ b/tests/toolboxes/secs/test_secs_inputs.py
@@ -1,0 +1,35 @@
+import datetime as dt
+
+from swarmx.toolboxes.secs import SecsInputSingleSat, SecsInputs
+
+
+def test_SecsInputSingleSat():
+    start = dt.datetime.fromisoformat("2022-01-01T00:00:00")
+    end = dt.datetime.fromisoformat("2022-01-01T00:01:00")
+    inputs = SecsInputSingleSat(
+        collection="SW_OPER_MAGA_LR_1B",
+        model="IGRF",
+        start_time=start,
+        end_time=end,
+        viresclient_kwargs=dict(asynchronous=False, show_progress=False),
+    )
+    assert len(inputs.xarray["Timestamp"]) == 60
+    assert "B_NEC" in inputs.xarray.data_vars
+    assert "B_NEC_Model" in inputs.xarray.data_vars
+
+
+def test_SecsInputs():
+    start = dt.datetime.fromisoformat("2022-01-01T00:00:00")
+    end = dt.datetime.fromisoformat("2022-01-01T00:01:00")
+    inputs = SecsInputs(
+        model="IGRF",
+        start_time=start,
+        end_time=end,
+        viresclient_kwargs=dict(asynchronous=False, show_progress=False),
+    )
+    for s in (inputs.s1, inputs.s2):
+        assert len(s.xarray["Timestamp"]) == 60
+        assert "B_NEC" in s.xarray.data_vars
+        assert "B_NEC_Model" in s.xarray.data_vars
+        assert "ApexLatitude" in s.xarray.data_vars
+        assert "ApexLongitude" in s.xarray.data_vars

--- a/tests/toolboxes/secs/test_secs_inputs.py
+++ b/tests/toolboxes/secs/test_secs_inputs.py
@@ -1,8 +1,15 @@
 import datetime as dt
 
-from swarmx.toolboxes.secs import SecsInputs, SecsInputSingleSat
+import pytest
+
+try:
+    from swarmx.toolboxes.secs import SecsInputs, SecsInputSingleSat
+except ImportError:
+    pass
 
 
+@pytest.mark.dsecs
+@pytest.mark.remote
 def test_SecsInputSingleSat():
     start = dt.datetime.fromisoformat("2022-01-01T00:00:00")
     end = dt.datetime.fromisoformat("2022-01-01T00:01:00")
@@ -18,6 +25,8 @@ def test_SecsInputSingleSat():
     assert "B_NEC_Model" in inputs.xarray.data_vars
 
 
+@pytest.mark.dsecs
+@pytest.mark.remote
 def test_SecsInputs():
     start = dt.datetime.fromisoformat("2022-01-01T00:00:00")
     end = dt.datetime.fromisoformat("2022-01-01T00:01:00")


### PR DESCRIPTION
Notes:
- This adds an optional pip install argument of `.[dsecs]` which is required for using the DSECS toolbox. This includes dependencies of `pyproj` and `apexpy` (which is problematic to install because of requiring a fortran compiler at present)
- I couldn't get apexpy installed on the GitHub runners for Windows so DSECS tests are skipped in that case